### PR TITLE
gave modals two columns. spaced out film information

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Purpose
 Mega Flix is a film database built for independent video stores to increase production, increase revenue, and attract new customers. This version of the application is for demo purposes and can be modified at many levels based on what the store in particular prefers.
 
-### Usage
+## Usage
 The user will be presented with a login page
 
 ![Alt text]((public/images/readme-login-large.png "Login"))
@@ -17,7 +17,7 @@ The user can then click on a movie and be presented with information about the f
 
 The user can also search for a film by title which will return all films that include the search term.
 
-### Manager Account
+## Manager Account
 
 If the user is the store manager they have access to the administrator account of the database/storefront.
 

--- a/public/customer-home.html
+++ b/public/customer-home.html
@@ -99,17 +99,31 @@
 
 
   <div class="modal fade" id="chosen-movie-modal" role="dialog">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg">
       <!-- Modal content-->
       <div class="modal-content">
         <div class="modal-header">
           <h4 class="modal-title"></h4>
         </div>
         <div class="modal-body">
-          <img id="modal-image">
-          <p id="modal-info"></p>
-          <p id="modal-plot"></p>
-          <div id="modal-reserved"></div>
+          <div class="container">
+            <div class="row">
+              <div class="col-md-6">
+                <img id="modal-image">
+              </div>
+              <div class="col-md-6">
+                  <p id="modal-info"></p>
+                  <p id="modal-runtime"></p>
+                  <p id="modal-director"></p>
+                  <p id="modal-plot"></p><br>
+                  <div id="modal-reserved"></div>
+              </div>
+
+
+            </div>
+
+          </div>
+
           <!-- <button id="reserve-button">Reserve Film</button> -->
         </div>
         <div class="modal-footer">

--- a/public/js/customer-home.js
+++ b/public/js/customer-home.js
@@ -10,6 +10,8 @@ $(document).ready(function() {
   var modalTitle = $(".modal-title");
   var modalPoster = $("#modal-image");
   var modalInfo = $("#modal-info");
+  var modalRuntime = $("#modal-runtime");
+  var modalDirector = $("#modal-director");
   var modalPlot = $("#modal-plot");
   var modalReserved = $("#modal-reserved");
   
@@ -215,7 +217,10 @@ $(document).ready(function() {
       }).then(function(modalOMDB) {
         modalTitle.text(movieInfo[0].title);
         modalPoster.attr("src", modalOMDB.Poster);
-        modalInfo.text("Year of Release: " + modalOMDB.Year + "; Runtime: " + modalOMDB.Runtime + "; Director: " + modalOMDB.Director);
+        modalInfo.text("Year of Release: " + modalOMDB.Year);
+        modalRuntime.text("Runtime: " + modalOMDB.Runtime);
+        console.log("FIND IT "+ JSON.stringify(modalOMDB));
+        modalDirector.text("Director: " + modalOMDB.Director);
         modalPlot.text(modalOMDB.Plot);
         if (movieInfo[0].isReserved) {
           modalReserved.empty();


### PR DESCRIPTION
Updated two things

- Year of release, director and film runtime are now on separate lines
- Film poster appears on the left and the data on the right for each modal

Considered
- I considered having the genres populate here as well, but the genres in the database are from IMdB and there could be some discrepancies. Some post demo fixes could be to update the genres (by hand) to reflect OMdB's genres.